### PR TITLE
Update Message Preview Trigger

### DIFF
--- a/Misc/message link.gotmpl
+++ b/Misc/message link.gotmpl
@@ -1,5 +1,5 @@
 {{/*
-	Trigger: https://(?:\w+\.)?discord(?:app)?\.com/channels\/(\d+)\/(\d+)\/(\d+)
+	Trigger: (?:[^<]|\A)https://(?:\w+\.)?discord(?:app)?\.com/channels\/(\d+)\/(\d+)\/(\d+)(?:[^>\d]|\z)
 	Trigger Type: Regex
 
 	Usage:


### PR DESCRIPTION
Effectively simulates the behavior Discord shows with links, embedding links per default, but not when we have a format as follows.
```
<https://sample-link.url>
```

Fixes #16 