### PR TITLE
Add snippet name validation

### DIFF
--- a/Snippets/snippet.yag
+++ b/Snippets/snippet.yag
@@ -75,8 +75,13 @@
 				{{if eq (index .CmdArgs 1|lower) "add" "new" "create"}}
 					{{/*Add New Snippet*/}}
 						{{$args := parseArgs 5 (print "`;" (index .CmdArgs 0|lower) " " (index .CmdArgs 1|lower) " <Name1/Name2> <ImagURL> <Text>` Leave image as `\"\"` if you have no image") (carg "string" "") (carg "string" "") (carg "string" "name") (carg "string" "image") (carg "string" "content")}}
-						{{dbSet 0 (print "snippet_" ($args.Get 2|lower)) (sdict "image" ($args.Get 3) "value" ($args.Get 4) "author" .User.String)}}
-						{{addReactions "👌"}}
+
+						{{if $err := reFind "[^\\w/]" ($args.Get 2)}}
+							{{sendMessage nil (printf "Invalid character `%q` in snippet name!" $err)}}
+						{{else}}
+							{{dbSet 0 (print "snippet_" ($args.Get 2|lower)) (sdict "image" ($args.Get 3) "value" ($args.Get 4) "author" .User.String)}}
+							{{addReactions "👌"}}
+						{{end}}
 				{{else if eq (index .CmdArgs 1|lower) "del" "delete" "rem" "remove"}}
 					{{/*Delete Snippet*/}}
 						{{$args := parseArgs 3 (print "`;" (index .CmdArgs 0|lower) " " (index .CmdArgs 1|lower) " <Name1/Name2>`") (carg "string" "") (carg "string" "") (carg "string" "name")}}

--- a/Snippets/snippet.yag
+++ b/Snippets/snippet.yag
@@ -78,6 +78,8 @@
 
 						{{if $err := reFind "[^\\w/]" ($args.Get 2)}}
 							{{sendMessage nil (printf "Invalid character `%q` in snippet name!" $err)}}
+						{{else if not ($args.Get 2)}}
+							{{sendMessage nil "Snippet name cannot be empty."}}
 						{{else}}
 							{{dbSet 0 (print "snippet_" ($args.Get 2|lower)) (sdict "image" ($args.Get 3) "value" ($args.Get 4) "author" .User.String)}}
 							{{addReactions "👌"}}


### PR DESCRIPTION
This PR adds a naming requirement for adding snippets.  
Allowed characters are already enforced by the snippet viewing code (see [L104](https://github.com/galen8183/yagpdb-cc-2/blob/8303e278e2bfdb8910eec8b3a8606851b5969b62/Snippets/snippet.yag#L104), previously L99).  
Regular expression used for validation is `[^\w/]` (equivalent to `[^a-zA-Z0-9_/]`)  

This also now disallows empty snippet names, which previously caused an index error upon using `;""`  