### PR TITLE
Escape guild member mentions in linked messages with embeds

### DIFF
--- a/Misc/message_link.yag
+++ b/Misc/message_link.yag
@@ -106,8 +106,9 @@
 				{{end}}
 
 				{{$mentions := reFindAll `<@!?\d{17,19}>` $msg2.content}}{{$content2 := reSplit `<@!?\d{17,19}>` $msg2.content}}{{$msg2.Set "content" ""}}
-				{{range $i, $u := $mentions}}
-					{{- $uStr := $u}}{{with getMember $u}}{{$uStr = print "@" .User.String}}{{end}}
+				{{range $i, $u := $mentions}}{{$tmp := ""}}
+					{{- $uStr := ""}}{{range $msg.Mentions}}{{if in $u (str .ID)}}{{$uStr = print "@" .String}}{{end}}{{end}}
+					{{- if not $uStr}}{{with getMember $u}}{{$uStr = print "@" .User.String}}{{else}}{{$uStr = $u}}{{end}}{{end}}
 					{{- $msg2.Set "content" (print $msg2.content (index $content2 $i) $uStr) -}}
 				{{end}}
 

--- a/Misc/message_link.yag
+++ b/Misc/message_link.yag
@@ -36,7 +36,7 @@
 			"footer" (sdict
 				"text" (print "Command triggered by " .User.String ". Message from"))
 			"timestamp" $msg.Timestamp}}
-		
+
 		{{/*Anti overflow embed*/}}
 		{{$fields := cslice}}{{$desc := ""}}
 		{{if gt (len $mc) 2000}}
@@ -48,7 +48,7 @@
 		{{else}}
 			{{$desc = (print "\n\n**[Message](" (index $m 0 0) ") in <#" $msg.ChannelID ">**\n" $mc)}}
 		{{end}}
-		
+
 		{{if and $msg.Content (not $msg.Embeds)}}
 			{{$e.Set "description" $desc}}
 		{{end}}
@@ -97,15 +97,23 @@
 			{{end}}
 		{{end}}
 		{{if $msg.Embeds}}
-			{{if $reminder}}{{$embed2 := ""}}
+			{{if $reminder}}{{$msg2 := sdict}}
 				{{if eq (index $msg.Embeds 0).Type "rich"}}
-					{{$embed2 = index $msg.Embeds 0}}
-					{{sendMessage nil (complexMessage "embed" $embed2 "content" $content)}}
+					{{$embed2 := index $msg.Embeds 0}}
+					{{$msg2 = sdict "embed" $embed2 "content" $content}}
 				{{else if ne (index $msg.Embeds 0).Type "image"}}
-					{{sendMessage nil $mc}}
+					{{$msg2.Set "content" $mc}}
 				{{end}}
+
+				{{$mentions := reFindAll `<@!?\d{17,19}>` $msg2.content}}{{$content2 := reSplit `<@!?\d{17,19}>` $msg2.content}}{{$msg2.Set "content" ""}}
+				{{range $i, $u := $mentions}}
+					{{- $uStr := $u}}{{with getMember $u}}{{$uStr = print "@" .User.String}}{{end}}
+					{{- $msg2.Set "content" (print $msg2.content (index $content2 $i) $uStr) -}}
+				{{end}}
+
+				{{$msg2.Set "content" (print $msg2.content (len $content2|add -1|index $content2))}}
 				{{$e.Set "description" (print "**[Embed Link](" (index $m 0 0) ") to <#" $msg.ChannelID ">**")}}
-				{{sendMessage nil (cembed $e)}}
+				{{sendMessage nil (complexMessage $msg2)}}{{sendMessage nil (cembed $e)}}
 			{{end}}
 		{{end}}
 		{{if and (eq (len (index $m 0 0)) (len .Message.Content)) (not .Message.Attachments)}}


### PR DESCRIPTION
This PR resolves #16  
User mentions of members currently in the guild are replaced with the user string, prepended with '@'  
See attached image for an example of this, with both guild members and non member mentions (yellow text added for clarity)  
![Screenshot_2022-02-27_04-10-32](https://user-images.githubusercontent.com/95080649/155876240-927d5af1-0940-46f3-8b2c-fec4fb9b40c4.png)
