### PR TITLE
Enhance Database Reset Commands

### DIFF
--- a/Database_Management/reset/dbresetall.yag
+++ b/Database_Management/reset/dbresetall.yag
@@ -14,26 +14,32 @@
 Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, SendTTSMessages, ManageMessages, EmbedLinks, AttachFiles, ReadMessageHistory, MentionEveryone, VoiceConnect, VoiceSpeak, VoiceMuteMembers, VoiceDeafenMembers, VoiceMoveMembers, VoiceUseVAD, ManageNicknames, ManageRoles, ManageWebhooks, ManageEmojis, CreateInstantInvite, KickMembers, BanMembers, ManageChannels, AddReactions, ViewAuditLogs*/}}
 
 {{if not .ExecData}}
-	{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
+
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
+		{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
+
 		{{if eq (len .CmdArgs) 0}}
 			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
+
 			{{$msgID := sendMessageRetID nil (cembed
 				"title" "Hold up!"
 				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`%d` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetall %s`\nThe above code will expire in <t:%d:R> (60 seconds from now)" dbCount $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
 				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
 				"color" 0xBE1931
 			)}}
-			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $rand "msgid" $msgID) 60}}
+
 			{{deleteMessage nil $msgID 60}}
+			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $rand "msgid" $msgID) 60}}
 		{{else}}
 			{{with (dbGet .User.ID "dbresetall").Value}}
 				{{if eq $.StrippedMsg .code}}
-					{{$all := dbCount}}
-					{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-					{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "count" 0)}}
 					{{deleteTrigger 1}}
 					{{deleteMessage nil .msgid 0}}
+
+					{{$all := dbCount}}
+					{{$msgID := sendMessageRetID nil (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `0/%d`\nEstimated end time: <t:%d:T> (<t:%[2]d:R>)\nDon't run `dbresetall` before the end time!\nYou will be pinged when the database is cleared :)" $all (or (and $.IsPremium 9) 1|mult 100|fdiv $all|mult 8.0|add currentTime.Unix 8)) "color" 0xFAA61A)}}
+
+					{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "count" 0)}}
 				{{else}}
 					{{sendMessage nil (print "Wrong code provided. Use `" $prefix "dbresetall` to get a new code")}}
 				{{end}}
@@ -48,26 +54,22 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{$data := .ExecData}}
 	{{$count := 1}}
 
-	{{if .IsPremium}}
-		{{range seq 0 9}}
-			{{- if $count}}
-				{{- $count = dbDelMultiple (sdict "pattern" "%") 100 0}}
-				{{- $data.Set "count" (add $data.count $count)}}
-			{{- end -}}
-		{{end}}
-	{{else}}
-		{{$count = dbDelMultiple (sdict "pattern" "%") 100 0}}
-		{{$data.Set "count" (add $data.count $count)}}
+	{{range seq 0 (or (and .IsPremium 9) 1)}}
+		{{- if $count}}
+			{{- $count = dbDelMultiple (sdict "pattern" "%") 100 0}}
+			{{- $data.Set "count" (add $data.count $count)}}
+		{{- end -}}
 	{{end}}
 
-	{{if $count}}
-		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all dbCount) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+	{{if $dbcount := dbCount}}
+		{{editMessage nil $data.id (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `%d/%d`\nEstimated end time: <t:%d:T> (<t:%[3]d:R>)\nDon't run `dbresetall` before the end time!\nYou will be pinged when the database is cleared :)" $data.count $data.all (or (and $.IsPremium 9) 1|mult 100|fdiv (sub $data.all $data.count)|mult 8.0|add 8 currentTime.Unix)) "color" 0xFAA61A)}}
 		{{execCC .CCID nil 8 $data}}
 	{{else}}
-		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
-		"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
-		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
-		"color" 0x43B581))}}
 		{{deleteMessage nil $data.id 0}}
+		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
+			"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
+			"description" (printf "Deleted entries: `%d`\nElapsed time: `%.2fs` (%s)" $data.count ($t:=currentTime.Sub $data.time).Seconds (humanizeDurationSeconds $t))
+			"color" 0x43B581
+		))}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetall.yag
+++ b/Database_Management/reset/dbresetall.yag
@@ -18,7 +18,12 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{if eq (len .CmdArgs) 0}}
 			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`" dbCount "` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetall " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
+			{{$x := sendMessageRetID nil (cembed
+				"title" "Hold up!"
+				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`%d` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetall %s`\nThe above code will expire in <t:%d:R> (60 seconds from now)" dbCount $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
+				"color" 0xBE1931
+			)}}
 			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $random "msgid" $x) 60}}
 			{{deleteMessage nil $x 60}}
 		{{else}}

--- a/Database_Management/reset/dbresetall.yag
+++ b/Database_Management/reset/dbresetall.yag
@@ -17,8 +17,7 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{if eq (len .CmdArgs) 0}}
-			{{$cslice := split "abcdefghijklmnopqrstuvwxyz" ""|shuffle}}
-			{{$random := ""}}{{range (seq 0 10)}}{{$r := index (shuffle (cslice 0 1)) 0}}{{if eq $r 1}}{{$random = print $random (upper (index $cslice .))}}{{else}}{{$random = print $random (index $cslice .)}}{{end}}{{end}}
+			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
 			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`" dbCount "` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetall " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
 			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $random "msgid" $x) 60}}
 			{{deleteMessage nil $x 60}}

--- a/Database_Management/reset/dbresetall.yag
+++ b/Database_Management/reset/dbresetall.yag
@@ -17,20 +17,21 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{if eq (len .CmdArgs) 0}}
-			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-			{{$x := sendMessageRetID nil (cembed
+			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
+			{{$msgID := sendMessageRetID nil (cembed
 				"title" "Hold up!"
-				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`%d` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetall %s`\nThe above code will expire in <t:%d:R> (60 seconds from now)" dbCount $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE THE `ENTIRE` YAGPDB DATABASE (`%d` ENTRIES) ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetall %s`\nThe above code will expire in <t:%d:R> (60 seconds from now)" dbCount $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
 				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
 				"color" 0xBE1931
 			)}}
-			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $random "msgid" $x) 60}}
-			{{deleteMessage nil $x 60}}
+			{{dbSetExpire .User.ID "dbresetall" (sdict "code" $rand "msgid" $msgID) 60}}
+			{{deleteMessage nil $msgID 60}}
 		{{else}}
 			{{with (dbGet .User.ID "dbresetall").Value}}
 				{{if eq $.StrippedMsg .code}}
-					{{$x := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" dbCount ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-					{{execCC $.CCID nil 6 (sdict "id" $x "all" dbCount "time" currentTime "count" 0)}}
+					{{$all := dbCount}}
+					{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+					{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "count" 0)}}
 					{{deleteTrigger 1}}
 					{{deleteMessage nil .msgid 0}}
 				{{else}}
@@ -44,29 +45,29 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 		{{sendMessage nil (cembed "title" "Missing permissions" "description" (print "<:cross:705738821110595607> You are missing the permission `" $perms "` to use this command!") "color" 0xDD2E44)}}
 	{{end}}
 {{else}}
-	{{$c := 1}}
-	{{$count := 0}}
+	{{$data := .ExecData}}
+	{{$count := 1}}
+
 	{{if .IsPremium}}
-		{{range (seq 0 9)}}
-			{{- if ne $c 0 -}}
-				{{- $c = dbDelMultiple (sdict "pattern" "%") 100 0 -}}
-				{{- $count = add $count $c -}}
+		{{range seq 0 9}}
+			{{- if $count}}
+				{{- $count = dbDelMultiple (sdict "pattern" "%") 100 0}}
+				{{- $data.Set "count" (add $data.count $count)}}
 			{{- end -}}
 		{{end}}
 	{{else}}
 		{{$count = dbDelMultiple (sdict "pattern" "%") 100 0}}
+		{{$data.Set "count" (add $data.count $count)}}
 	{{end}}
-	{{$dbcount := dbCount}}
-	{{$sdict := .ExecData}}
-	{{$sdict.Set "count" (add $count $sdict.count)}}
-	{{if ne $dbcount 0}}
-		{{editMessage nil $sdict.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub .ExecData.all $dbcount) "/" .ExecData.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-		{{execCC .CCID nil 8 $sdict}}
+
+	{{if $count}}
+		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all dbCount) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetall again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+		{{execCC .CCID nil 8 $data}}
 	{{else}}
 		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
 		"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
-		"description" (print "Deleted entries: " $sdict.count "\nExpired time: " (toDuration (print ((currentTime.Sub $sdict.time).Seconds|roundCeil) "s")))
+		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
 		"color" 0x43B581))}}
-		{{deleteMessage nil $sdict.id 0}}
+		{{deleteMessage nil $data.id 0}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetkey.yag
+++ b/Database_Management/reset/dbresetkey.yag
@@ -19,9 +19,10 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 		{{$args := parseArgs 1 (print $prefix "dbresetkey <Key/Code>") (carg "string" "<Key/Code>")}}
 		{{with (dbGet .User.ID "dbresetkey").Value}}
 			{{if eq ($args.Get 0|str) .code}}
-				{{$x := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" (dbCount .key) ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+				{{$all := dbCount .key}}
+				{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
 				{{dbDel $.User.ID "dbresetkey"}}
-				{{execCC $.CCID nil 6 (sdict "id" $x "all" (dbCount .key) "time" currentTime "key" .key "count" 0)}}
+				{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "key" .key "count" 0)}}
 				{{deleteTrigger 1}}
 				{{deleteMessage nil .msgid 0}}
 			{{else}}
@@ -30,42 +31,43 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 				{{deleteMessage nil .msgid 0}}
 			{{end}}
 		{{else}}
-			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-				{{$x := sendMessageRetID nil (cembed
+			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
+				{{$msgID := sendMessageRetID nil (cembed
 					"title" "Hold up!"
-					"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE NAME `%s` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetkey %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+					"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE NAME `%s` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetkey %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
 					"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
 					"color" 0xBE1931
 				)}}
-			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $random "msgid" $x "key" ($args.Get 0)) 60}}
-			{{deleteMessage nil $x 60}}
+			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $rand "msgid" $msgID "key" ($args.Get 0)) 60}}
+			{{deleteMessage nil $msgID 60}}
 		{{end}}
 	{{else}}
 		{{sendMessage nil (cembed "title" "Missing permissions" "description" (print "<:cross:705738821110595607> You are missing the permission `" $perms "` to use this command!") "color" 0xDD2E44)}}
 	{{end}}
 {{else}}
-	{{$c := 1}}
-	{{$count := 0}}
+	{{$data := .ExecData}}
+	{{$count := 1}}
+
 	{{if .IsPremium}}
-		{{range (seq 0 9)}}
-			{{- if ne $c 0 -}}
-				{{- $c = dbDelMultiple (sdict "pattern" $.ExecData.key) 100 0 -}}
-				{{- $count = add $count $c -}}
+		{{range seq 0 9}}
+			{{- if $count}}
+				{{- $count = dbDelMultiple (sdict "pattern" $data.key) 100 0}}
+				{{- $data.Set "count" (add $data.count $count)}}
 			{{- end -}}
 		{{end}}
 	{{else}}
-		{{$count = dbDelMultiple (sdict "pattern" $.ExecData.key) 100 0}}
+		{{$count = dbDelMultiple (sdict "pattern" $data.key) 100 0}}
+		{{$data.Set "count" (add $data.count $count)}}
 	{{end}}
-	{{$sdict := .ExecData}}
-	{{$sdict.Set "count" (add $count $sdict.count)}}
-	{{if ne $c 0}}
-		{{editMessage nil .ExecData.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub .ExecData.all (dbCount .ExecData.key)) "/" .ExecData.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-		{{execCC .CCID nil 8 $sdict}}
+
+	{{if $count}}
+		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all (dbCount $data.key)) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+		{{execCC .CCID nil 8 $data}}
 	{{else}}
 		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
-		"title" (print "I am done resetting \"" $sdict.key "\"! <:wolfyey:664130162023202816>")
-		"description" (print "Deleted entries: " $sdict.count "\nExpired time: " (toDuration (print ((currentTime.Sub $sdict.time).Seconds|roundCeil) "s")))
+		"title" (print "I am done resetting \"" $data.key "\"! <:wolfyey:664130162023202816>")
+		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
 		"color" 0x43B581))}}
-		{{deleteMessage nil $sdict.id 0}}
+		{{deleteMessage nil $data.id 0}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetkey.yag
+++ b/Database_Management/reset/dbresetkey.yag
@@ -17,29 +17,33 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
 		{{$args := parseArgs 1 (print $prefix "dbresetkey <Key/Code>") (carg "string" "<Key/Code>")}}
+
 		{{with (dbGet .User.ID "dbresetkey").Value}}
+			{{dbDel $.User.ID "dbresetkey"}}
+			{{deleteMessage nil .msgid 0}}
+
 			{{if eq ($args.Get 0|str) .code}}
-				{{$all := dbCount .key}}
-				{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-				{{dbDel $.User.ID "dbresetkey"}}
-				{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "key" .key "count" 0)}}
 				{{deleteTrigger 1}}
-				{{deleteMessage nil .msgid 0}}
+
+				{{$all := dbCount .key}}
+				{{$msgID := sendMessageRetID nil (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `0/%d`\nEstimated end time: <t:%d:T> (<t:%[2]d:R>)\nDon't run `dbresetkey` before the end time!\nYou will be pinged when the entries are cleared :)" $all (or (and $.IsPremium 9) 1|mult 100|fdiv $all|mult 8.0|add currentTime.Unix 8)) "color" 0xFAA61A)}}
+
+				{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "key" .key "count" 0)}}
 			{{else}}
-				{{dbDel $.User.ID "dbresetkey"}}
 				{{sendMessage nil (print "Wrong code provided. Use `" $prefix "dbresetkey <Key>` and generate a new code.")}}
-				{{deleteMessage nil .msgid 0}}
 			{{end}}
 		{{else}}
 			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
-				{{$msgID := sendMessageRetID nil (cembed
-					"title" "Hold up!"
-					"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE NAME `%s` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetkey %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
-					"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
-					"color" 0xBE1931
-				)}}
-			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $rand "msgid" $msgID "key" ($args.Get 0)) 60}}
+
+			{{$msgID := sendMessageRetID nil (cembed
+				"title" "Hold up!"
+				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE NAME `%s` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetkey %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
+				"color" 0xBE1931
+			)}}
+
 			{{deleteMessage nil $msgID 60}}
+			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $rand "msgid" $msgID "key" ($args.Get 0)) 60}}
 		{{end}}
 	{{else}}
 		{{sendMessage nil (cembed "title" "Missing permissions" "description" (print "<:cross:705738821110595607> You are missing the permission `" $perms "` to use this command!") "color" 0xDD2E44)}}
@@ -48,26 +52,22 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{$data := .ExecData}}
 	{{$count := 1}}
 
-	{{if .IsPremium}}
-		{{range seq 0 9}}
-			{{- if $count}}
-				{{- $count = dbDelMultiple (sdict "pattern" $data.key) 100 0}}
-				{{- $data.Set "count" (add $data.count $count)}}
-			{{- end -}}
-		{{end}}
-	{{else}}
-		{{$count = dbDelMultiple (sdict "pattern" $data.key) 100 0}}
-		{{$data.Set "count" (add $data.count $count)}}
+	{{range seq 0 (or (and .IsPremium 9) 1)}}
+		{{- if $count}}
+			{{- $count = dbDelMultiple (sdict "pattern" $data.key) 100 0}}
+			{{- $data.Set "count" (add $data.count $count)}}
+		{{- end -}}
 	{{end}}
 
-	{{if $count}}
-		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all (dbCount $data.key)) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+	{{if $dbcount := dbCount $data.key}}
+		{{editMessage nil $data.id (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `%d/%d`\nEstimated end time: <t:%d:T> (<t:%[3]d:R>)\nDon't run `dbresetkey` before the end time!\nYou will be pinged when the entries are cleared :)" $data.count $data.all (or (and $.IsPremium 9) 1|mult 100|fdiv (sub $data.all $data.count)|mult 8.0|add 8 currentTime.Unix)) "color" 0xFAA61A)}}
 		{{execCC .CCID nil 8 $data}}
 	{{else}}
-		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
-		"title" (print "I am done resetting \"" $data.key "\"! <:wolfyey:664130162023202816>")
-		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
-		"color" 0x43B581))}}
 		{{deleteMessage nil $data.id 0}}
+		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
+			"title" (print "I am done resetting \"" $data.key "\"! <:wolfyey:664130162023202816>")
+			"description" (printf "Key: `%s`\nDeleted entries: `%d`\nElapsed time: `%.2fs` (%s)" $data.key $data.count ($t:=currentTime.Sub $data.time).Seconds (humanizeDurationSeconds $t))
+			"color" 0x43B581
+		))}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetkey.yag
+++ b/Database_Management/reset/dbresetkey.yag
@@ -31,8 +31,7 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 				{{deleteMessage nil .msgid 0}}
 			{{end}}
 		{{else}}
-			{{$cslice := split "abcdefghijklmnopqrstuvwxyz" ""|shuffle}}
-			{{$random := ""}}{{range (seq 0 10)}}{{$r := index (shuffle (cslice 0 1)) 0}}{{if eq $r 1}}{{$random = print $random (upper (index $cslice .))}}{{else}}{{$random = print $random (index $cslice .)}}{{end}}{{end}}
+			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
 			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE `" ($args.Get 0|dbCount) "` ENTRIES WITH THE NAME `" ($args.Get 0) "` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetkey " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
 			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $random "msgid" $x "key" ($args.Get 0)) 60}}
 			{{deleteMessage nil $x 60}}

--- a/Database_Management/reset/dbresetkey.yag
+++ b/Database_Management/reset/dbresetkey.yag
@@ -16,8 +16,7 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 {{if not .ExecData}}
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
-		{{$args := parseArgs 1 (print $prefix "dbresetkey <Key/Code>")
-			(carg "string" "<Key/Code>")}}
+		{{$args := parseArgs 1 (print $prefix "dbresetkey <Key/Code>") (carg "string" "<Key/Code>")}}
 		{{with (dbGet .User.ID "dbresetkey").Value}}
 			{{if eq ($args.Get 0|str) .code}}
 				{{$x := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" (dbCount .key) ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetkey again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
@@ -32,7 +31,12 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 			{{end}}
 		{{else}}
 			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE `" ($args.Get 0|dbCount) "` ENTRIES WITH THE NAME `" ($args.Get 0) "` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetkey " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
+				{{$x := sendMessageRetID nil (cembed
+					"title" "Hold up!"
+					"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE NAME `%s` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetkey %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+					"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
+					"color" 0xBE1931
+				)}}
 			{{dbSetExpire .User.ID "dbresetkey" (sdict "code" $random "msgid" $x "key" ($args.Get 0)) 60}}
 			{{deleteMessage nil $x 60}}
 		{{end}}

--- a/Database_Management/reset/dbresetuser.yag
+++ b/Database_Management/reset/dbresetuser.yag
@@ -20,9 +20,10 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 			(carg "string" "<UserID/Code>")}}
 		{{with (dbGet .User.ID "dbresetuser").Value}}
 				{{if eq ($args.Get 0|str) .code}}
-					{{$x := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" (dbCount .user) ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+					{{$all := dbCount .user}}
+					{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
 					{{dbDel $.User.ID "dbresetuser"}}
-					{{execCC $.CCID nil 6 (sdict "id" $x "all" (dbCount .user) "time" currentTime "user" .user "count" 0)}}
+					{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "user" .user "count" 0)}}
 					{{deleteTrigger 1}}
 					{{deleteMessage nil .msgid 0}}
 				{{else}}
@@ -32,43 +33,43 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 				{{end}}
 		{{else}}
 			{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>") (carg "userid" "<UserID/Code>")}}
-			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-			{{$x := sendMessageRetID nil (cembed
+			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
+			{{$msgID := sendMessageRetID nil (cembed
 				"title" "Hold up!"
-				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE USERID `%d` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetuser %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE USERID `%d` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetuser %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
 				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
 				"color" 0xBE1931
 			)}}
-			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $random "msgid" $x "user" ($args.Get 0)) 60}}
-			{{deleteMessage nil $x 60}}
+			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $rand "msgid" $msgID "user" ($args.Get 0)) 60}}
+			{{deleteMessage nil $msgID 60}}
 		{{end}}
 	{{else}}
 		{{sendMessage nil (cembed "title" "Missing permissions" "description" (print "<:cross:705738821110595607> You are missing the permission `" $perms "` to use this command!") "color" 0xDD2E44)}}
 	{{end}}
 {{else}}
-	{{$c := 1}}
-	{{$count := 0}}
+	{{$data := .ExecData}}
+	{{$count := 1}}
+
 	{{if .IsPremium}}
-		{{range (seq 0 9)}}
-			{{- if ne $c 0 -}}
-				{{- $c = dbDelMultiple (sdict "userID" $.ExecData.user) 100 0 -}}
-				{{- $count = add $count $c -}}
+		{{range seq 0 9}}
+			{{- if $count}}
+				{{- $count = dbDelMultiple (sdict "userID" $data.user) 100 0}}
+				{{- $data.Set "count" (add $data.count $count)}}
 			{{- end -}}
 		{{end}}
 	{{else}}
-		{{$count = dbDelMultiple (sdict "userID" $.ExecData.user) 100 0}}
+		{{$count = dbDelMultiple (sdict "userID" $data.user) 100 0}}
+		{{$data.Set "count" (add $data.count $count)}}
 	{{end}}
-	{{$dbcount := dbCount .ExecData.user}}
-	{{$sdict := .ExecData}}
-	{{$sdict.Set "count" (add $count $sdict.count)}}
-	{{if ne $c 0}}
-		{{editMessage nil .ExecData.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub .ExecData.all $dbcount) "/" .ExecData.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-		{{execCC .CCID nil 8 $sdict}}
+
+	{{if $count}}
+		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all (dbCount $data.user)) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+		{{execCC .CCID nil 8 $data}}
 	{{else}}
 		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
 		"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
-		"description" (print "Deleted entries: " $sdict.count "\nExpired time: " (toDuration (print ((currentTime.Sub $sdict.time).Seconds|roundCeil) "s")))
+		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
 		"color" 0x43B581))}}
-		{{deleteMessage nil $sdict.id 0}}
+		{{deleteMessage nil $data.id 0}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetuser.yag
+++ b/Database_Management/reset/dbresetuser.yag
@@ -16,32 +16,35 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 {{if not .ExecData}}
 	{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 		{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
-		{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>")
-			(carg "string" "<UserID/Code>")}}
+		{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>") (carg "string" "<UserID/Code>")}}
+
 		{{with (dbGet .User.ID "dbresetuser").Value}}
-				{{if eq ($args.Get 0|str) .code}}
-					{{$all := dbCount .user}}
-					{{$msgID := sendMessageRetID nil (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (0/" $all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
-					{{dbDel $.User.ID "dbresetuser"}}
-					{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "user" .user "count" 0)}}
-					{{deleteTrigger 1}}
-					{{deleteMessage nil .msgid 0}}
-				{{else}}
-					{{dbDel $.User.ID "dbresetuser"}}
-					{{sendMessage nil (print "Wrong code provided. Use `" $prefix "dbresetuser <UserID>` and generate a new code.")}}
-					{{deleteMessage nil .msgid 0}}
-				{{end}}
+			{{dbDel $.User.ID "dbresetuser"}}
+			{{deleteMessage nil .msgid 0}}
+
+			{{if eq ($args.Get 0|str) .code}}
+				{{deleteTrigger 1}}
+
+				{{$all := dbCount .user}}
+				{{$msgID := sendMessageRetID nil (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `0/%d`\nEstimated end time: <t:%d:T> (<t:%[2]d:R>)\nDon't run `dbresetuser` before the end time!\nYou will be pinged when the entries are cleared :)" $all (or (and $.IsPremium 9) 1|mult 100|fdiv $all|mult 8.0|add currentTime.Unix 8)) "color" 0xFAA61A)}}
+
+				{{execCC $.CCID nil 6 (sdict "id" $msgID "all" $all "time" currentTime "user" .user "count" 0)}}
+			{{else}}
+				{{sendMessage nil (print "Wrong code provided. Use `" $prefix "dbresetuser <UserID>` and generate a new code.")}}
+			{{end}}
 		{{else}}
 			{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>") (carg "userid" "<UserID/Code>")}}
 			{{$rand := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$rand = printf "%s%c" $rand (add $x 26|randInt $x)}}{{end}}
+
 			{{$msgID := sendMessageRetID nil (cembed
 				"title" "Hold up!"
 				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE USERID `%d` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetuser %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $rand (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
 				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
 				"color" 0xBE1931
 			)}}
-			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $rand "msgid" $msgID "user" ($args.Get 0)) 60}}
+
 			{{deleteMessage nil $msgID 60}}
+			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $rand "msgid" $msgID "user" ($args.Get 0)) 60}}
 		{{end}}
 	{{else}}
 		{{sendMessage nil (cembed "title" "Missing permissions" "description" (print "<:cross:705738821110595607> You are missing the permission `" $perms "` to use this command!") "color" 0xDD2E44)}}
@@ -50,26 +53,22 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 	{{$data := .ExecData}}
 	{{$count := 1}}
 
-	{{if .IsPremium}}
-		{{range seq 0 9}}
-			{{- if $count}}
-				{{- $count = dbDelMultiple (sdict "userID" $data.user) 100 0}}
-				{{- $data.Set "count" (add $data.count $count)}}
-			{{- end -}}
-		{{end}}
-	{{else}}
-		{{$count = dbDelMultiple (sdict "userID" $data.user) 100 0}}
-		{{$data.Set "count" (add $data.count $count)}}
+	{{range seq 0 (or (and .IsPremium 9) 1)}}
+		{{- if $count}}
+			{{- $count = dbDelMultiple (sdict "userID" $data.user) 100 0}}
+			{{- $data.Set "count" (add $data.count $count)}}
+		{{- end -}}
 	{{end}}
 
-	{{if $count}}
-		{{editMessage nil $data.id (cembed "author" (sdict "icon_url" "https://cdn.discordapp.com/emojis/714051544265392229.gif" "name" (print "This might take a while... (" (sub $data.all (dbCount $data.user)) "/" $data.all ")")) "description" "Please wait until the command is done running.\n**Do not run dbresetuser again until it is finished!**\nYou will be pinged if the reset is done :)" "color" 0xFAA61A)}}
+	{{if $dbcount := dbCount $data.user}}
+		{{editMessage nil $data.id (cembed "description" (printf "<a:load:714051544265392229> Deleting DB entries... `%d/%d`\nEstimated end time: <t:%d:T> (<t:%[3]d:R>)\nDon't run `dbresetuser` before the end time!\nYou will be pinged when the entries are cleared :)" $data.count $data.all (or (and $.IsPremium 9) 1|mult 100|fdiv (sub $data.all $data.count)|mult 8.0|add 8 currentTime.Unix)) "color" 0xFAA61A)}}
 		{{execCC .CCID nil 8 $data}}
 	{{else}}
-		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
-		"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
-		"description" (print "Deleted entries: " $data.count "\nElapsed time: " (toDuration (print ((currentTime.Sub $data.time).Seconds|roundCeil) "s")))
-		"color" 0x43B581))}}
 		{{deleteMessage nil $data.id 0}}
+		{{sendMessage nil (complexMessage "content" .User.Mention "embed" (cembed
+			"title" "I am done resetting the database! <:wolfyey:664130162023202816>"
+			"description" (printf "User ID: `%d`\nDeleted entries: `%d`\nElapsed time: `%.2fs` (%s)" $data.user $data.count ($t:=currentTime.Sub $data.time).Seconds (humanizeDurationSeconds $t))
+			"color" 0x43B581
+		))}}
 	{{end}}
 {{end}}

--- a/Database_Management/reset/dbresetuser.yag
+++ b/Database_Management/reset/dbresetuser.yag
@@ -33,8 +33,7 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 		{{else}}
 			{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>")
 				(carg "userid" "<UserID/Code>")}}
-				{{$cslice := split "abcdefghijklmnopqrstuvwxyz" ""|shuffle}}
-			{{$random := ""}}{{range (seq 0 10)}}{{$r := index (shuffle (cslice 0 1)) 0}}{{if eq $r 1}}{{$random = print $random (upper (index $cslice .))}}{{else}}{{$random = print $random (index $cslice .)}}{{end}}{{end}}
+			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
 			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE `" ($args.Get 0|dbCount) "` ENTRIES WITH THE USERID `" ($args.Get 0) "` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetuser " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
 			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $random "msgid" $x "user" ($args.Get 0)) 60}}
 			{{deleteMessage nil $x 60}}

--- a/Database_Management/reset/dbresetuser.yag
+++ b/Database_Management/reset/dbresetuser.yag
@@ -31,10 +31,14 @@ Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, 
 					{{deleteMessage nil .msgid 0}}
 				{{end}}
 		{{else}}
-			{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>")
-				(carg "userid" "<UserID/Code>")}}
+			{{$args := parseArgs 1 (print $prefix "dbresetuser <UserID/Code>") (carg "userid" "<UserID/Code>")}}
 			{{$random := ""}}{{range seq 0 10}}{{$x := 97}}{{if randInt 2}}{{$x = 65}}{{end}}{{$random = printf "%s%c" $random (add $x 26|randInt $x)}}{{end}}
-			{{$x := sendMessageRetID nil (cembed "title" "Hold up!" "description" (print "**YOU ARE ABOUT TO DELETE `" ($args.Get 0|dbCount) "` ENTRIES WITH THE USERID `" ($args.Get 0) "` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n__If you still want to proceed type__") "footer" (sdict "text" (print $prefix "dbresetuser " $random) "icon_url" "https://cdn.discordapp.com/emojis/650328464825516062.png") "color" 0xBE1931 "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png"))}}
+			{{$x := sendMessageRetID nil (cembed
+				"title" "Hold up!"
+				"description" (printf "⚠️ **YOU ARE ABOUT TO DELETE `%d` ENTRIES WITH THE USERID `%d` FROM THE YAGPDB DATABASE ON THIS SERVER\n\nARE YOU SURE YOU WANT TO DO THIS?**\n**❗There is no going back once you confirmed❗**\n\n<:s:650328464825516062> __If you still want to proceed run__ `%sdbresetuser %s`\nThe above code will expire <t:%d:R> (60 seconds from now)" ($args.Get 0|dbCount) ($args.Get 0) $prefix $random (mult .TimeSecond 60|toDuration|currentTime.Add).Unix)
+				"thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")
+				"color" 0xBE1931
+			)}}
 			{{dbSetExpire .User.ID "dbresetuser" (sdict "code" $random "msgid" $x "user" ($args.Get 0)) 60}}
 			{{deleteMessage nil $x 60}}
 		{{end}}


### PR DESCRIPTION
This PR adds a number of small changes and features to the [dbreset scripts](~/Database_Management/reset).  

Overview of all changes:  
- Renamed some variables to be less ambiguous  
- Added timestamp(s) to status messages, including random code expiration and time until reset completion  
- Reduced DB interactions where possible  
- Prevent extra execCC before sending completion message  
- Change embed formatting and wording for more clarity (you can of course easily change this to whatever you think is reasonable)  
- Reduced redundancy, therefore less characters  
- Reformatted some code for better readability  
- Use truthiness instead of comparison operators in some conditional statements  
- Improve random code generation method (using `randInt` and `printf` instead of `shuffle`)  

In my testing, this seems to not have any of the known bugs, those being issue #36 and the very recent reports of invalid key errors.  